### PR TITLE
Add EASYHOME PureAIR Compact PREMIUM support.

### DIFF
--- a/aldes/product.py
+++ b/aldes/product.py
@@ -20,7 +20,8 @@ _MODES = {
 _DISPLAY_NAMES: Final = {
     'INSPIRAIR_HOME_S' : 'InspirAIR® Home S',
     'EASY_HOME_CONNECT' : 'EASYHOME PureAir Compact CONNECT',
-    'DEE_FLY_CUBE' : 'Dee Fly Cube'
+    'DEE_FLY_CUBE' : 'Dee Fly Cube',
+    'EASY_HOME_PREMIUM' : 'EASYHOME PureAIR Compact PREMIUM'
 }
 
 class AldesProduct:


### PR DESCRIPTION
Add EASYHOME PureAIR Compact PREMIUM support.
Tested well for four days at home.

![Aldes](https://github.com/aalmazanarbs/hassio_aldes/assets/123078627/3b5075e2-27ce-4b4f-8e66-e189cd4ccc1b)
